### PR TITLE
[config]打包加入默认配置文件

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,19 +73,23 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           cd target/release
-          7z a ../../${{ matrix.name }} rnacos.exe
+          cp ../../doc/conf/.env.example .env
+          7z a ../../${{ matrix.name }} rnacos.exe .env
           cd -
       - name: Archive binary (linux and macOS)
         if: ${{  matrix.os != 'windows-latest' && matrix.target !='x86_64-unknown-linux-musl' }}
         run: |
           cd target/release
-          tar czvf ../../${{ matrix.name }} rnacos
+          cp ../../doc/conf/.env.example .env
+          tar czvf ../../${{ matrix.name }} rnacos .env
           cd -
       - name: Archive binary (linux-musl)
         if: matrix.target =='x86_64-unknown-linux-musl'
         run: |
+          # 注意，下面进入了三级目录，与上面两个打包操作路径不同
           cd target/x86_64-unknown-linux-musl/release
-          tar czvf ../../../${{ matrix.name }} rnacos
+          cp ../../../doc/conf/.env.example .env
+          tar czvf ../../../${{ matrix.name }} rnacos .env
           cd -
 
       - name: Upload binary artifacts

--- a/doc/conf/.env.example
+++ b/doc/conf/.env.example
@@ -1,0 +1,41 @@
+# rnacos 指定配置文件有两种方式：
+# 1. 默认文件（放置于运行目录下，文件名为“.env”，自动读取）
+# 2. 指定文件（放置于任意目录下， 通过 命令行参数“-e 文件路径”形式指定， 如“./rnacos -e /etc/rnacos/conf/default.cnf”）
+# 更多说明请参照  https://r-nacos.github.io/r-nacos/deplay_env.html
+
+# r-nacos监听http端口，默认值：8848
+RNACOS_HTTP_PORT=8848
+
+#r-nacos监听grpc端口，默认值：HTTP端口+1000(即9848） 
+RNACOS_GRPC_PORT=9848
+
+#r-nacos独立控制台端口，默认值：HTTP端口+2000(即10848）;设置为0可不开启独立控制台
+RNACOS_HTTP_CONSOLE_PORT=10848
+
+#r-nacos控制台登录1小时失败次数限制默认是5,一个用户连续登陆失败5次，会被锁定1个小时 ，默认值：1
+RNACOS_CONSOLE_LOGIN_ONE_HOUR_LIMIT=5
+
+#http工作线程数，默认值：cpu核数 
+#RNACOS_HTTP_WORKERS=8
+
+#配置中心的本地数据库文件地址【0.2.x后不再使用】
+#RNACOS_CONFIG_DB_FILE=config.db
+
+#配置中心的本地数据库sled文件夹, 会在系统运行时自动创建 ，默认值：nacos_db
+RNACOS_CONFIG_DB_DIR=nacos_db
+
+#节点id，默认值：1
+RNACOS_RAFT_NODE_ID=1
+
+#节点地址Ip:GrpcPort,单节点运行时每次启动都会生效；多节点集群部署时，只取加入集群时配置的值，默认值：127.0.0.1:GrpcPort 
+RNACOS_RAFT_NODE_ADDR=127.0.0.1:9848
+
+#是否当做主节点初始化,(只在每一次启动时生效)节点1时默认为true,节点非1时为false 
+#RNACOS_RAFT_AUTO_INIT=true
+
+
+#是否当做节点加入对应的主节点,LeaderIp:GrpcPort；只在第一次启动时生效；默认值：空 
+#RNACOS_RAFT_JOIN_ADDR=127.0.0.1:9848
+
+#日志等级:debug,info,warn,error;所有http,grpc请求都会打info日志,如果不关注，可以设置为error 减少日志量，默认值：info
+RUST_LOG=info


### PR DESCRIPTION
在向同事推广rnacos的时候, 会遇到很多同事来问配置文件和配置参数,  所以向工程中加入了默认配置文件示例和打包默认配置文件, 方便无外网或者懒得查配置说明的用户快速了解参数修改配置.